### PR TITLE
Enum booking

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -3,4 +3,5 @@ class Booking < ApplicationRecord
   belongs_to :treehouse
 
   validates :number_of_guests, :check_in, :check_out, presence: true
+  enum status: %i[approved pending rejected], _default: "pending"
 end

--- a/db/migrate/20220525142707_add_status_to_booking.rb
+++ b/db/migrate/20220525142707_add_status_to_booking.rb
@@ -1,0 +1,5 @@
+class AddStatusToBooking < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bookings, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_25_132609) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_25_142707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_25_132609) do
     t.bigint "treehouse_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
     t.index ["treehouse_id"], name: "index_bookings_on_treehouse_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
Adding status to booking - I followed this tuto : https://naturaily.com/blog/ruby-on-rails-enum
We can now use on any **instance** of Booking the following : 
booking.status # will return the current status 
booking.approved! # will set the status to approved (same with .pending! and .rejected!)
booking.approved? # will return true or false

We can use on the **class** Booking : 
Booking.approved # will return all approved bookings
Booking.pending
Booking.rejected

Default value set to "pending" so no need to specify when creating an instance of booking.